### PR TITLE
fix: update logger middleware

### DIFF
--- a/service/middlewares/logger.js
+++ b/service/middlewares/logger.js
@@ -2,6 +2,12 @@ import morgan from "morgan";
 import fs from "fs";
 import path from "path";
 
+// Create the logs folder if it doesn't exist
+const logsDirectory = path.join("logs");
+if (!fs.existsSync(logsDirectory)) {
+    fs.mkdirSync(logsDirectory, { recursive: true });
+}
+
 // Create a writable stream for file logging
 const logStream = fs.createWriteStream(path.join("logs", "access.log"), {
     flags: "a",


### PR DESCRIPTION
Fixed logger middleware to check for and create the 'logs' directory if it doesn't exist.